### PR TITLE
Improvements to ImagesModel

### DIFF
--- a/harbour-sailorgram/harbour-sailorgram.pro
+++ b/harbour-sailorgram/harbour-sailorgram.pro
@@ -12,8 +12,9 @@
 # The name of your application
 TARGET = harbour-sailorgram
 
-CONFIG += sailfishapp \
-       += c++11
+CONFIG += \
+    sailfishapp \
+    c++11
 
 QT += sql dbus multimedia concurrent
 

--- a/harbour-sailorgram/qml/pages/selector/SelectorImagesPage.qml
+++ b/harbour-sailorgram/qml/pages/selector/SelectorImagesPage.qml
@@ -188,12 +188,13 @@ Page
                     active: model.isDir
                     anchors.bottom: parent.bottom
                     width: view.cellWidth
-                    height: Math.min(item.contentHeight, view.cellHeight * 2 / 3)
+                    height: active && !!item ? Math.min(item.contentHeight, view.cellHeight * 2 / 3) : 0
 
                     sourceComponent: Label {
                         text: model.name
                         horizontalAlignment: Qt.AlignHCenter
                         wrapMode: Text.Wrap
+                        clip: true
                     }
                 }
 

--- a/harbour-sailorgram/src/selector/imagesmodelworker.cpp
+++ b/harbour-sailorgram/src/selector/imagesmodelworker.cpp
@@ -8,18 +8,42 @@
 
 ImagesModelWorker::ImagesModelWorker(QObject *parent) : QObject(parent)
 {
-    qRegisterMetaType<ImagesModel::Entry>();
 }
 
-void ImagesModelWorker::scanDirectory(const QString &dirPath, const QStringList &filterList, bool recursive)
+void ImagesModelWorker::handleRequest(const ImagesModel::Request &request)
+{
+    if (request == this->_lastrequest)
+    {
+        emit requestComplete(this->_lastrequest, this->_lastlist);
+        return;
+    }
+
+    ImagesModel::EntryList entryList;
+
+    if (request.rootDir != this->_lastrequest.rootDir || request.recursive != this->_lastrequest.recursive)
+        entryList = scanDirectory(request.rootDir, ImagesModel::_filterlist, request.recursive);
+    else
+        entryList = this->_lastlist;
+
+    sort(&entryList, request.sortOrder, request.sortRole, request.directoriesFirst);
+
+    this->_lastlist = entryList;
+    this->_lastrequest = request;
+
+    emit requestComplete(request, entryList);
+}
+
+ImagesModel::EntryList ImagesModelWorker::scanDirectory(const QString &path, const QStringList &filterList, bool recursive)
 {
     ImagesModel::EntryList entryList;
 
-    QDir directory(dirPath);
+    QDir directory(path);
 
     if (directory.exists())
     {
         QFileInfoList list = directory.entryInfoList(filterList, QDir::NoDotAndDotDot | QDir::AllDirs | QDir::Files | QDir::Readable);
+
+        entryList.reserve(list.size());
 
         foreach (const QFileInfo &fileInfo, list)
         {
@@ -27,13 +51,13 @@ void ImagesModelWorker::scanDirectory(const QString &dirPath, const QStringList 
 
             ImagesModel::Entry entry;
             entry.path = filePath;
-            entry.name = fileInfo.fileName();
+            entry.path.squeeze();
             entry.date = fileInfo.lastModified().toMSecsSinceEpoch();
 
             if (fileInfo.isDir())
             {
                 if (recursive)
-                    scanDirectory(filePath, filterList, recursive);
+                    entryList << scanDirectory(filePath, filterList, recursive);
                 else
                 {
                     entry.isDir = true;
@@ -80,5 +104,126 @@ void ImagesModelWorker::scanDirectory(const QString &dirPath, const QStringList 
         }
     }
 
-    emit scanComplete(entryList, dirPath);
+    return entryList;
+}
+
+void ImagesModelWorker::sort(ImagesModel::EntryList *list, Qt::SortOrder sortOrder, ImagesModel::Role sortRole, bool directoriesFirst)
+{
+    switch (sortOrder)
+    {
+        case Qt::AscendingOrder:
+        {
+            switch(sortRole)
+            {
+                case ImagesModel::PathRole:
+                    std::sort(list->begin(), list->end(), lesserPathThan);
+                    break;
+
+                case ImagesModel::UrlRole:
+                    std::sort(list->begin(), list->end(), lesserPathThan);
+                    break;
+
+                case ImagesModel::NameRole:
+                    std::sort(list->begin(), list->end(), lesserNameThan);
+                    break;
+
+                case ImagesModel::DateRole:
+                    std::sort(list->begin(), list->end(), lesserDateThan);
+                    break;
+
+                case ImagesModel::OrientationRole:
+                    std::sort(list->begin(), list->end(), lesserOrientationThan);
+                    break;
+
+                case ImagesModel::IsDirRole:
+                    std::sort(list->begin(), list->end(), lesserIsDirThan);
+                    break;
+            }
+            break;
+        }
+
+        case Qt::DescendingOrder:
+        {
+            switch(sortRole)
+            {
+                case ImagesModel::PathRole:
+                    std::sort(list->begin(), list->end(), biggerPathThan);
+                    break;
+
+                case ImagesModel::UrlRole:
+                    std::sort(list->begin(), list->end(), biggerPathThan);
+                    break;
+
+                case ImagesModel::NameRole:
+                    std::sort(list->begin(), list->end(), biggerNameThan);
+                    break;
+
+                case ImagesModel::DateRole:
+                    std::sort(list->begin(), list->end(), biggerDateThan);
+                    break;
+
+                case ImagesModel::OrientationRole:
+                    std::sort(list->begin(), list->end(), biggerOrientationThan);
+                    break;
+
+                case ImagesModel::IsDirRole:
+                    std::sort(list->begin(), list->end(), biggerIsDirThan);
+                    break;
+            }
+            break;
+        }
+    }
+
+    if (directoriesFirst)
+        std::stable_sort(list->begin(), list->end(), biggerIsDirThan);
+}
+
+bool ImagesModelWorker::lesserPathThan(const ImagesModel::Entry &e1, const ImagesModel::Entry &e2)
+{
+    return e1.path.compare(e2.path) < 0;
+}
+
+bool ImagesModelWorker::lesserNameThan(const ImagesModel::Entry &e1, const ImagesModel::Entry &e2)
+{
+    return e1.path.split('/').last().compare(e2.path.split('/').last()) < 0;
+}
+
+bool ImagesModelWorker::lesserDateThan(const ImagesModel::Entry &e1, const ImagesModel::Entry &e2)
+{
+    return e1.date < e2.date;
+}
+
+bool ImagesModelWorker::lesserOrientationThan(const ImagesModel::Entry &e1, const ImagesModel::Entry &e2)
+{
+    return e1.orientation < e2.orientation;
+}
+
+bool ImagesModelWorker::lesserIsDirThan(const ImagesModel::Entry &e1, const ImagesModel::Entry &e2)
+{
+    return !e1.isDir && e2.isDir;
+}
+
+bool ImagesModelWorker::biggerPathThan(const ImagesModel::Entry &e1, const ImagesModel::Entry &e2)
+{
+    return e1.path.compare(e2.path) > 0;
+}
+
+bool ImagesModelWorker::biggerNameThan(const ImagesModel::Entry &e1, const ImagesModel::Entry &e2)
+{
+    return e1.path.split('/').last().compare(e2.path.split('/').last()) > 0;
+}
+
+bool ImagesModelWorker::biggerDateThan(const ImagesModel::Entry &e1, const ImagesModel::Entry &e2)
+{
+    return e1.date > e2.date;
+}
+
+bool ImagesModelWorker::biggerOrientationThan(const ImagesModel::Entry &e1, const ImagesModel::Entry &e2)
+{
+    return e1.orientation > e2.orientation;
+}
+
+bool ImagesModelWorker::biggerIsDirThan(const ImagesModel::Entry &e1, const ImagesModel::Entry &e2)
+{
+    return e1.isDir && !e2.isDir;
 }

--- a/harbour-sailorgram/src/selector/imagesmodelworker.h
+++ b/harbour-sailorgram/src/selector/imagesmodelworker.h
@@ -12,15 +12,35 @@ class ImagesModelWorker : public QObject
     Q_OBJECT
 
 public:
+
     ImagesModelWorker(QObject *parent = Q_NULLPTR);
 
-signals:
-    void scanComplete(ImagesModel::EntryList, QString dirPath);
-
 public slots:
-    void scanDirectory(const QString &dirPath, const QStringList &filterList, bool recursive);
+
+    void handleRequest(const ImagesModel::Request &request);
+
+signals:
+
+    void requestComplete(ImagesModel::Request, ImagesModel::EntryList);
 
 private:
+
+    static bool lesserPathThan(const ImagesModel::Entry &e1, const ImagesModel::Entry &e2);
+    static bool lesserDateThan(const ImagesModel::Entry &e1, const ImagesModel::Entry &e2);
+    static bool lesserNameThan(const ImagesModel::Entry &e1, const ImagesModel::Entry &e2);
+    static bool lesserOrientationThan(const ImagesModel::Entry &e1, const ImagesModel::Entry &e2);
+    static bool lesserIsDirThan(const ImagesModel::Entry &e1, const ImagesModel::Entry &e2);
+    static bool biggerPathThan(const ImagesModel::Entry &e1, const ImagesModel::Entry &e2);
+    static bool biggerDateThan(const ImagesModel::Entry &e1, const ImagesModel::Entry &e2);
+    static bool biggerNameThan(const ImagesModel::Entry &e1, const ImagesModel::Entry &e2);
+    static bool biggerOrientationThan(const ImagesModel::Entry &e1, const ImagesModel::Entry &e2);
+    static bool biggerIsDirThan(const ImagesModel::Entry &e1, const ImagesModel::Entry &e2);
+
+    void sort(ImagesModel::EntryList *list, Qt::SortOrder sortOrder, ImagesModel::Role sortRole, bool directoriesFirst);
+    ImagesModel::EntryList scanDirectory(const QString &path, const QStringList &filterList, bool reqursive);
+
+    ImagesModel::EntryList _lastlist;
+    ImagesModel::Request _lastrequest;
 };
 
 #endif // IMAGESMODELWORKER_H


### PR DESCRIPTION
Moved sorting to background thread to avoid lagging in large folders. Additionally the label that shows the foldername in the gridview delegate now clips very large names.
Unfortunately I wasn't able to come up with an idea to efficiently display folders in a list on top without significantly reducing flicking performance. Maybe somebody else has an idea?
