### PR TITLE
Allow scaling on MediaPhotoPage.qml

### DIFF
--- a/harbour-sailorgram/qml/pages/media/MediaPhotoPage.qml
+++ b/harbour-sailorgram/qml/pages/media/MediaPhotoPage.qml
@@ -1,5 +1,6 @@
 import QtQuick 2.1
 import Sailfish.Silica 1.0
+import Sailfish.Gallery 1.0
 import harbour.sailorgram.TelegramQml 1.0
 import "../../models"
 import "../../components"
@@ -34,39 +35,11 @@ MediaPage
             anchors { left: parent.left; top: parent.top; right: parent.right }
         }
 
-        /*
-        PinchArea
-        {
-            property int initialWidth
-            property int initialHeight
-
-            anchors.fill: parent
-            pinch.target: image
-            pinch.dragAxis: Pinch.XAndYAxis
-            pinch.minimumScale: 1
-            pinch.maximumScale: 10
-
-            onPinchStarted: {
-                initialWidth = image.sourceSize.width
-                initialHeight = image.sourceSize.height
-            }
-
-            onPinchUpdated: {
-                flickable.contentX += pinch.previousCenter.x - pinch.center.x;
-                flickable.contentY += pinch.previousCenter.y - pinch.center.y;
-            }
-
-            onPinchFinished: flickable.returnToBounds()
-        }
-        */
-
-        Image
+        ImageViewer
         {
             id: image
             anchors.fill: parent
-            fillMode: Image.PreserveAspectFit
-            asynchronous: true
-            cache: false
+            enableZoom: !flickable.moving
             source: fileHandler.filePath
 
             BusyIndicator


### PR DESCRIPTION
Use ImageViewer from Sailfish.Gallery instead of Image to allow scaling with centring on pinch centre.

I don't know is it ok to use items from Sailfish.Gallery module but it is preinstalled and cannot be removed. So it is on your decision.
