### PR TITLE
Add ability to copy the contact's phone number to clipboard

### DIFF
--- a/harbour-sailorgram/qml/items/user/UserInfo.qml
+++ b/harbour-sailorgram/qml/items/user/UserInfo.qml
@@ -64,12 +64,34 @@ Item
             visible: user.phone.length > 0
         }
 
-        Label
+        BackgroundItem
         {
-            x: Theme.paddingMedium
-            width: parent.width - (x * 2)
-            text: TelegramHelper.phoneNumber(user)
-            visible: user.phone.length > 0
+            id: phoneitem
+            height: phonelabel.height + phonemenu.height
+
+            onPressAndHold: phonemenu.show(phoneitem)
+
+            Label
+            {
+                id: phonelabel
+                anchors { left: parent.left; leftMargin: Theme.paddingMedium; top: parent.top; right: parent.right; rightMargin: Theme.paddingMedium }
+                height: Theme.itemSizeSmall
+                verticalAlignment: Text.AlignVCenter
+                text: TelegramHelper.phoneNumber(user)
+                visible: user.phone.length > 0
+            }
+
+            ContextMenu
+            {
+                id: phonemenu
+
+                MenuItem
+                {
+                    text: qsTr("Copy to clipboard")
+
+                    onClicked: Clipboard.text = phonelabel.text
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
I don't know is it really a useful feature but I had to write out phone numbers to add them to my phone book manually for several times.

Also I noticed that the ContactPage has a UserInfo item with left padding ([lines 43-44](https://github.com/Dax89/harbour-sailorgram/blob/master/harbour-sailorgram/qml/pages/contacts/ContactPage.qml#L43-44)) but UserInfo already has padding inside ClickableLabels.
