### PR TITLE
SelectorImagesPage.qml - use plural qsTr() for images count

### DIFF
--- a/harbour-sailorgram/harbour-sailorgram.pro
+++ b/harbour-sailorgram/harbour-sailorgram.pro
@@ -99,6 +99,7 @@ OTHER_FILES += qml/harbour-sailorgram.qml \
     rpm/harbour-sailorgram.spec \
     rpm/harbour-sailorgram.yaml \
     translations/*.ts \
+    translations/translations.json \
     lipstick/*.conf \
     harbour-sailorgram.desktop \
     qml/pages/login/ConnectionPage.qml \
@@ -184,7 +185,7 @@ TRANSLATIONS += translations/harbour-sailorgram-be.ts \
                 translations/harbour-sailorgram-nl_NL.ts \
                 translations/harbour-sailorgram-ru.ts \
                 translations/harbour-sailorgram-sv.ts \
-                translations/harbour-sailorgram-uk_UA.ts
+                translations/harbour-sailorgram-uk_UA.ts \
                 translations/harbour-sailorgram.ts
 
 HEADERS += \

--- a/harbour-sailorgram/qml/pages/selector/SelectorFilesPage.qml
+++ b/harbour-sailorgram/qml/pages/selector/SelectorFilesPage.qml
@@ -65,7 +65,8 @@ Dialog
         DialogHeader
         {
             id: header
-            acceptText: qsTr("Send %1 file(s)").arg(selectedFiles.length)
+            acceptText: selectedFiles.length ? qsTr("Send %n file(s)", "", selectedFiles.length) :
+                                               qsTr("Select files")
             title: filesmodel.folder
         }
 

--- a/harbour-sailorgram/qml/pages/selector/SelectorImagesPage.qml
+++ b/harbour-sailorgram/qml/pages/selector/SelectorImagesPage.qml
@@ -142,7 +142,8 @@ Dialog
         DialogHeader
         {
             id: header
-            acceptText: qsTr("Send %1 image(s)").arg(selectedFiles.length)
+            acceptText: selectedFiles.length ? qsTr("Send %n image(s)", "", selectedFiles.length) :
+                                               qsTr("Select images")
             cancelText: !!rootPage ? qsTr("Back") : qsTr("Cancel")
             title: filesmodel.folder.split('/').pop();
         }

--- a/harbour-sailorgram/translations/harbour-sailorgram.ts
+++ b/harbour-sailorgram/translations/harbour-sailorgram.ts
@@ -794,8 +794,15 @@ Do a swype to the right to select a contact</source>
         <source>Back</source>
         <translation type="unfinished"></translation>
     </message>
+    <message numerus="yes">
+        <source>Send %n file(s)</source>
+        <translation>
+            <numerusform>Send %n file</numerusform>
+            <numerusform>Send %n files</numerusform>
+        </translation>
+    </message>
     <message>
-        <source>Send %1 file(s)</source>
+        <source>Select files</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -830,15 +837,22 @@ Do a swype to the right to select a contact</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Send %1 image(s)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <source>Send %n image(s)</source>
+        <translation>
+            <numerusform>Send %n image</numerusform>
+            <numerusform>Send %n images</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Select images</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -999,6 +1013,10 @@ Do a swype to the right to select a contact</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>%1 added %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Secret chat created by ��%1��</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1008,10 +1026,6 @@ Do a swype to the right to select a contact</source>
     </message>
     <message>
         <source>Group name changed to ��%1��</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>%1 added %2</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1106,6 +1120,10 @@ Do a swype to the right to select a contact</source>
     </message>
     <message>
         <source>Actions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Copy to clipboard</source>
         <translation type="unfinished"></translation>
     </message>
 </context>


### PR DESCRIPTION
- Add ability to use local plurals for the _"Send # images"_ label in localizations
- Show _"Select images"_ label when now files are selected
