### PR TITLE
Improve typing status and add ability delete multiple messages

### DIFF
--- a/harbour-sailorgram/qml/items/dialog/DialogTextInput.qml
+++ b/harbour-sailorgram/qml/items/dialog/DialogTextInput.qml
@@ -56,25 +56,15 @@ InverseMouseArea
 
     Timer
     {
-        id: timstoptyping
-        interval: 3000 // 3 seconds
-        onTriggered: context.telegram.messagesSetTyping(TelegramHelper.peerId(dialog), false);
-    }
-
-    Timer
-    {
-        id: timtyping
-        triggeredOnStart: true
-        interval: 3000 // 3 seconds
-        onTriggered: context.telegram.messagesSetTyping(TelegramHelper.peerId(dialog), true);
+        id: typingtimer
+        interval: 3000
 
         function startTyping() {
-            timstoptyping.restart();
-
-            if(running)
-                return;
-
-            timtyping.restart();
+            if(!running)
+            {
+                start();
+                context.telegram.messagesSetTyping(TelegramHelper.peerId(dialog), running);
+            }
         }
     }
 
@@ -86,7 +76,7 @@ InverseMouseArea
         font.pixelSize: Theme.fontSizeSmall
         placeholderText: qsTr("Message...")
         textRightMargin: 0
-        onTextChanged: timtyping.startTyping()
+        onTextChanged: typingtimer.startTyping()
 
         anchors {
             left: parent.left

--- a/harbour-sailorgram/qml/items/message/messageitem/MessageItem.qml
+++ b/harbour-sailorgram/qml/items/message/messageitem/MessageItem.qml
@@ -12,6 +12,7 @@ import "../../../js/TelegramHelper.js" as TelegramHelper
 
 ListItem
 {
+    property bool selected: false
     property Context context
     property MessageTypesPool messageTypesPool
     property Dialog dialog
@@ -102,6 +103,7 @@ ListItem
     }
 
     id: messageitem
+    anchors { topMargin: Theme.paddingSmall; bottomMargin: Theme.paddingSmall }
     contentWidth: parent.width
     contentHeight: content.height
     onClicked: displayMedia()
@@ -244,17 +246,15 @@ ListItem
 
                 var params = { "context": messageitem.context, "message": messageitem.message, "maxWidth": content.maxw - 2 * Theme.paddingMedium };
 
-                if(media.classType === TelegramConstants.typeMessageMediaDocument) {
+                var classtype = media.classType;
+
+                if(classtype === TelegramConstants.typeMessageMediaDocument) {
                     if(context.telegram.documentIsSticker(media.document))
                         messageTypesPool.stickerComponent.createObject(mediacontainer, params);
                     else
                         messageTypesPool.documentComponent.createObject(mediacontainer, params);
-
-                    return;
                 }
-
-                var classtype = media.classType;
-                if(classtype === TelegramConstants.typeMessageMediaPhoto)
+                else if(classtype === TelegramConstants.typeMessageMediaPhoto)
                     messageTypesPool.photoComponent.createObject(mediacontainer, params);
                 else if(classtype === TelegramConstants.typeMessageMediaAudio)
                     messageTypesPool.audioComponent.createObject(mediacontainer, params);

--- a/harbour-sailorgram/qml/pages/dialogs/DialogPage.qml
+++ b/harbour-sailorgram/qml/pages/dialogs/DialogPage.qml
@@ -57,6 +57,11 @@ Page
         anchors { left: parent.left; top: parent.top; right: parent.right }
     }
 
+    RemorsePopup
+    {
+        id: remorce
+    }
+
     SilicaFlickable
     {
         anchors.fill: parent
@@ -64,6 +69,26 @@ Page
         PullDownMenu
         {
             id: pulldownmenu
+
+            MenuItem
+            {
+                text: messageview.selectionMode ? qsTr("Cancel selection") : qsTr("Select messages")
+                onClicked: messageview.selectionMode = !messageview.selectionMode
+            }
+
+            MenuItem
+            {
+                text: qsTr("Select all")
+                visible: messageview.selectionMode && messageview.selectedItems.length !== messageview.model.count
+                onClicked: messageview.selectAll()
+            }
+
+            MenuItem
+            {
+                text: qsTr("Clear selection")
+                visible: messageview.selectedItems.length > 0
+                onClicked: messageview.clearSelection()
+            }
 
             MenuItem
             {
@@ -94,7 +119,7 @@ Page
         MessageView
         {
             id: messageview
-            anchors { left: parent.left; top: header.bottom; right: parent.right; bottom: parent.bottom }
+            anchors { left: parent.left; top: header.bottom; right: parent.right; bottom: selectionactions.top }
             context: dialogpage.context
             forwardedMessage: dialogpage.forwardedMessage
 
@@ -120,6 +145,37 @@ Page
                     return "";
 
                 return TelegramHelper.completeName(dialogpage.user);
+            }
+
+            onSelectedItemsChanged: selectionactions.open = selectedItems.length > 0
+        }
+
+        DockedPanel
+        {
+            id: selectionactions
+            width: parent.width
+            height: deleteselected.height + Theme.paddingMedium
+            open: false
+            visible: visibleSize > 0.0
+
+            onOpenChanged: if(!open && messageview.selectedItems.length > 0) messageview.selectionMode = false
+
+            Image
+            {
+                anchors.fill: parent
+                fillMode: Image.PreserveAspectFit
+                source: "image://theme/graphic-gradient-edge"
+            }
+
+            IconButton
+            {
+                id: deleteselected
+                anchors.centerIn: parent
+                icon.source: "image://theme/icon-m-delete?" + (pressed ? Theme.highlightColor : Theme.primaryColor)
+                onClicked: remorce.execute(qsTr("Deleting Messages"), function() {
+                    messageview.deleteSelected();
+                    messageview.selectionMode = false;
+                })
             }
         }
     }


### PR DESCRIPTION
##### 1) Improve sending of typing status

When using two timers one for sending _set typing true_ and another for _set typing false_ the "typing" status expires after about 9 seconds. But if send only _set typing true_ it expires after 6 seconds like in the the original desktop application. So there is no need to send _set typing false_ as it only increases the "typing" status expiration time (bug in the library?).
##### 2) Add ability to select and delete multiple messages in dialogue
- Add pull down menu entry to enable selection mode
- Add pull down menu entries to select all / clear selection
- Add docked panel to delete selected messages (with remorse popup)
